### PR TITLE
Lint for stylesheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ $ npm install --global eslint
 $ npm install --global mocha
 ```
 
+You can also install scss_lint if you want to check the stylesheets
+```sh
+$ gem install scss_lint
+```
+
 #### Install packages a
 ```sh
 $ npm install
@@ -26,6 +31,35 @@ $ bower install
 
 #### Run gulp:
 
+Serve a local development website:
 ```sh
 $ gulp serve
 ```
+
+Build a static website:
+```sh
+$ gulp
+```
+
+Inject dependencies in the html pages:
+```sh
+$ gulp wiredep
+```
+
+Check the javascript:
+```sh
+$ gulp lint
+```
+
+Check the stylesheets:
+```sh
+$ gulp lint:scss
+```
+
+Check the tests:
+```sh
+$ gulp lint:test
+```
+
+
+

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -5,6 +5,7 @@ import browserSync from 'browser-sync';
 import del from 'del';
 import {stream as wiredep} from 'wiredep';
 import mocha from 'gulp-mocha';
+import scsslint from 'gulp-scss-lint';
 
 const $ = gulpLoadPlugins();
 const reload = browserSync.reload;
@@ -51,6 +52,10 @@ const testLintOptions = {
 
 gulp.task('lint', lint('app/scripts/**/*.js'));
 gulp.task('lint:test', lint('test/spec/**/*.js', testLintOptions));
+gulp.task('lint:scss', function() {
+  return gulp.src('app/styles/*.scss')
+    .pipe(scsslint());
+});
 
 gulp.task('test', ['scripts', 'lint'], () => {
   return gulp.src('test/spec/**/*.js')

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gulp-mocha": "^2.2.0",
     "gulp-plumber": "^1.0.1",
     "gulp-sass": "^2.0.0",
+    "gulp-scss-lint": "^0.3.9",
     "gulp-size": "^1.2.1",
     "gulp-sourcemaps": "^1.5.0",
     "gulp-uglify": "^1.1.0",


### PR DESCRIPTION
Checks for several issues in sass code and provides some conventions (commenting, spaces, etc.)

See details here:
https://github.com/brigade/scss-lint/blob/master/lib/scss_lint/linter/README.md

Implemented as an optional gulp task because it requires `ruby` and `scss_lint` to be installed. Sass also requires ruby so it shouldn't be a an issue for most people who use sass. But the npm package only uses the c version (libsass) so it does introduce an extra dependency. 