### PR TITLE
disable invalid tests, example of working tests with nock

### DIFF
--- a/test/spec/nock-example.js
+++ b/test/spec/nock-example.js
@@ -1,0 +1,88 @@
+// globals: nock
+(function () {
+  "use strict";
+  var fetch = require("node-fetch");
+  var nock = require("nock");
+  var assert = require("chai").assert;
+
+  describe("Example of nock", function() {
+    describe("How to fake a response", function() {
+
+
+      // Create a MessageSceneCreate without options, we should have an empty options object (nulll)
+      it("Should be possible to call nock twice", function(done) {
+
+        // Define a fake server that responds with json data
+        nock("http://0.0.0.0")
+          .defaultReplyHeaders({
+            "Content-Type": "application/json"
+          })
+          .post("/scene/create", {
+            name: "nock-test"
+          })
+          .reply(200, {
+            result: "ok"
+          });
+
+
+        // Post a request, this should return "result.ok"
+        // Note that we use the modern fetch api and not the $.ajax api from jquery.
+        // $.ajax is not supported.
+        // https://github.com/node-nock/nock/issues/527
+        // "Nock only mocks the node HTTP client, and jQuery is not using that..."
+        fetch("http://0.0.0.0/scene/create", {
+          method: "POST",
+          headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            name: "nock-test"
+          })
+        })
+          .then(function(resp) {
+            return resp.json();
+          })
+          .then(function(data) {
+            assert.equal(data.result, "ok");
+          })
+          .catch(function(error) {
+            console.error("request failed with error", error);
+            done();
+          });
+
+
+        // Now the second thing you should be aware off
+        // notice the big "READ THIS" in the documentation
+        // https://github.com/node-nock/nock#read-this---about-interceptors
+        // After request is intercepted that interceptor is removed. It only works for 1 request.
+        // So the 2nd time it should return an error
+        fetch("http://0.0.0.0/scene/create", {
+          method: "POST",
+          headers: {
+            "Accept": "application/json",
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({
+            name: "nock-test"
+          })
+        })
+          .then(function(resp) {
+            assert.fail("request should work only once");
+            return resp.json();
+          })
+          .then(function(data) {
+            console.log("got unexpected data", data);
+            assert.fail("request should work only once");
+            done();
+          })
+          .catch(function(error) {
+            // We should have some error (something truthy will do).
+            assert.isOk(error, "we got an expected error");
+            done();
+          });
+
+      });
+    });
+  });
+}());

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -118,7 +118,7 @@
       });
 
 
-      it("Test scene creation - check create request - ok", function(done) {
+      xit("Test scene creation - check create request - ok", function(done) {
         var options = {
           name: "Model to create"
         };
@@ -194,7 +194,7 @@
       });
 
 
-      it("MessageSceneChangeState - Check sceneid being sent", function(done) {
+      xit("MessageSceneChangeState - Check sceneid being sent", function(done) {
 
         // Id of the scene we will start:
         var startid = 1;
@@ -259,7 +259,7 @@
     });
 
 
-    it("MessageSceneDelete - Check sceneid being sent", function(done) {
+    xit("MessageSceneDelete - Check sceneid being sent", function(done) {
 
       // Id of the scene we will start:
       var deleteid = 1;
@@ -307,7 +307,7 @@
   describe("MessageSceneList", function() {
 
 
-    it("MessageSceneList - Check if request is sent correctly", function(done) {
+    xit("MessageSceneList - Check if request is sent correctly", function(done) {
 
       var msl = new MessageSceneList();
 
@@ -338,7 +338,7 @@
     });
 
     // This one is todo!
-    it("MessageSceneList - Check if we get valid scenes", function(done) {
+    xit("MessageSceneList - Check if we get valid scenes", function(done) {
 
       var msl = new MessageSceneList();
 
@@ -411,7 +411,7 @@
       done();
     });
 
-    it("App - LoadTemplate - Check if mock template is added to DOM", function(mydone) {
+    xit("App - LoadTemplate - Check if mock template is added to DOM", function(mydone) {
 
       nock("http://0.0.0.0")
         .get("templates/templates.html")


### PR DESCRIPTION
Disabled 6 tests that were using nock in a way that should not work. There were two problems:
- nock only allows for 1 request per interceptor
- nock does not work with jquery.

I provided a nock example that works as documented, based on the fetch api. 