### PR TITLE
Added option to select what the user wants to download

### DIFF
--- a/app/scripts/components/modeldetails.js
+++ b/app/scripts/components/modeldetails.js
@@ -193,11 +193,17 @@ var exports = (function () {
           });
 
       },
+
       downloadFiles: function() {
         // Open download window
         var id = this.model.id;
 
-        window.open("/scene/export?id=" + id);
+        // Get array of checked download options.
+        var downloadOptions = $(".downloadoption:checked").map(function(){
+          return $(this).val();
+        }).get(); //
+
+        window.open("/scene/export?id=" + id + "&options=" + downloadOptions.join(";"));
       },
       // Remove item, based on incoming modelinfo.
       removeModel: function() {

--- a/app/scripts/components/modeldetails.js
+++ b/app/scripts/components/modeldetails.js
@@ -199,7 +199,7 @@ var exports = (function () {
         var id = this.model.id;
 
         // Get array of checked download options.
-        var downloadOptions = $(".downloadoption:checked").map(function(){
+        var downloadOptions = $(".downloadoption:checked").map(function() {
           return $(this).val();
         }).get(); //
 

--- a/app/templates/model-details.html
+++ b/app/templates/model-details.html
@@ -143,13 +143,16 @@
           <p>
             Please check what you would like to download. Your download will be a ZIP file which contains the requested files.
           </p>
-          <p>
-            Currently you can only dowload the generated output images.
-          </p>
+
           <div class="form-group input-group">
-            <span class="input-group-addon"><input type="checkbox" class="downloadoption" checked="checked" v-on:change="downloadOptionsChange()"></span>
+            <span class="input-group-addon"><input type="checkbox" class="downloadoption" checked="checked" value="export_images" v-on:change="downloadOptionsChange()"></span>
             <span class="form-control">Download generated output images</span>
           </div>
+          <div class="form-group input-group">
+            <span class="input-group-addon"><input type="checkbox" class="downloadoption" checked="checked" value="export_thirdparty" v-on:change="downloadOptionsChange()"></span>
+            <span class="form-control">Include export for RMS / Petrel</span>
+          </div>
+
           <div class="btn-group">
             <button class="form-control btn btn-primary" id="download-submit" v-on:click="downloadFiles()" value="">
               Download

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -521,13 +521,21 @@
     });
     it("Should be possible to download files", function(done) {
       var windowOpenCalled = false;
+      var oldOpen = global.window.open;
 
+      // mock open function
       global.window.open = function() {
         windowOpenCalled = true;
       };
 
+      // this should open a new window
       modelDetails.downloadFiles();
+
+      // did it?
       assert.equal(true, windowOpenCalled);
+
+      // restore open function
+      global.window.open = oldOpen;
 
       done();
 

--- a/test/spec/test.js
+++ b/test/spec/test.js
@@ -477,6 +477,19 @@
       done();
 
     });
+    it("Should be possible to download files", function(done) {
+      var windowOpenCalled = false;
+
+      global.window.open = function() {
+        windowOpenCalled = true;
+      };
+
+      modelDetails.downloadFiles();
+      assert.equal(true, windowOpenCalled);
+
+      done();
+
+    });
 
 
   });


### PR DESCRIPTION
User can now select to download images and/or third party data (I included both known types in the same option, I have no idea if these really need to be separate)

The download link will be generated automatically based upon the the selected options, separated with a semicolon for each option:

*eg:* export?id=292&options=export_images;export_thirdparty

where "export_thirdparty" is now the "RMS/Petrel" option.

This is only the front-end part.