### PR TITLE
Use vh units on image animation-frames to make image fit better on smaller screens?

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -362,6 +362,10 @@ $row-height: 32px;
 
 .animation-frame {
   max-width: 100%;
+
+  // Height should be smaller than max viewport height:
+  // Such that it will fit on smaller screens.
+  max-height: 60vh;
 }
 
 // Based upon btn but without all the hover fx, etc


### PR DESCRIPTION
The goal is to make them within viewport height, so no scrolling is
required to look at the images.