### PR TITLE
Disable scenario clone/delete buttons if scenario disappears from list

### DIFF
--- a/app/templates/finder-columns.html
+++ b/app/templates/finder-columns.html
@@ -9,10 +9,10 @@
             <div class="col-xs-2">
               <div class="btn-toolbar">
 
-                <button title="delete" v-on:click="removeScenario(model)" class="btn btn-primary pull-right" v-bind:class="{ 'inputdisabled': selectedScenarioId === -1 || isNaN(selectedScenarioId) === true || selectedScenarioId === undefined}" >
+                <button title="delete" v-on:click="removeScenario(model)" class="btn btn-primary pull-right" v-bind:class="{ 'inputdisabled': selectedScenarioId === -1 || isNaN(selectedScenarioId) === true || selectedScenarioId === undefined || scenarioList.selectedScenario === undefined}" >
                   <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
                 </button>
-                <button title="clone"  v-on:click="cloneScenario()" class="btn btn-primary pull-right" v-bind:class="{ 'inputdisabled': selectedScenarioId === -1 || isNaN(selectedScenarioId) === true || selectedScenarioId === undefined}" >
+                <button title="clone"  v-on:click="cloneScenario()" class="btn btn-primary pull-right" v-bind:class="{ 'inputdisabled': selectedScenarioId === -1 || isNaN(selectedScenarioId) === true || selectedScenarioId === undefined || scenarioList.selectedScenario === undefined}" >
                   <span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span>
                 </button>
                 <a title="create" href="#/scenarios/create" class="btn btn-primary pull-right" >


### PR DESCRIPTION
This fix works by checking if the selectedscenario in the list returns
an undefined. (We can maybe remove some of the other conditions but that
is something for later)