### PR TITLE
text-overflow for buttons in select

### DIFF
--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -74,10 +74,14 @@ dt {
 }
 
 
-div[data-toggle="collapse"] {
+*[data-toggle="collapse"] {
   cursor: pointer;
 }
 
 .no-padding {
   padding: 0;
+}
+
+.bs-actionsbox .btn-group button {
+  @include text-overflow();
 }


### PR DESCRIPTION
If column is small overflow text (for me sediment overflows, rights do not). 